### PR TITLE
Use Noto Sans font on alarm page

### DIFF
--- a/alarm.html
+++ b/alarm.html
@@ -6,7 +6,11 @@
   <title>Sleep Alarm Calculator</title>
   <!-- Tailwind CSS CDN -->
   <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans&display=swap" rel="stylesheet">
   <style>
+    body {
+      font-family: 'Noto Sans', sans-serif;
+    }
     /* ------------------------------------ */
     /* 1) Custom range‐slider styling       */
     /* ------------------------------------ */


### PR DESCRIPTION
## Summary
- load Noto Sans from Google Fonts
- apply Noto Sans as the body font

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68400643880883318dca6b41edb4b538